### PR TITLE
removed -o & -ms-box-sizing

### DIFF
--- a/src/skel-noscript.css
+++ b/src/skel-noscript.css
@@ -25,8 +25,6 @@
 	*, *:before, *:after {
 		-moz-box-sizing: border-box;
 		-webkit-box-sizing: border-box;
-		-o-box-sizing: border-box;
-		-ms-box-sizing: border-box;
 		box-sizing: border-box;
 	}
 */
@@ -93,10 +91,8 @@
 
 		.row > * {
 			float: left;
-			-moz-box-sizing: border-box;
-			-webkit-box-sizing: border-box;
-			-o-box-sizing: border-box;
-			-ms-box-sizing: border-box;
+			-moz-box-sizing: border-box; /* Firefox <= 28 */
+			-webkit-box-sizing: border-box; /* Android <= 3, Safari <= 5, Blacberry 7 */
 			box-sizing: border-box;
 		}
 


### PR DESCRIPTION
Never needed:
http://caniuse.com/css3-boxsizing
http://css-tricks.com/almanac/properties/b/box-sizing/
http://www.paulirish.com/2012/box-sizing-border-box-ftw/
Firefox will drop prefix soon: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing, https://bugzilla.mozilla.org/show_bug.cgi?id=243412
