### PR TITLE
Fixed IE8 Fallback

### DIFF
--- a/src/skel.js
+++ b/src/skel.js
@@ -884,12 +884,12 @@ var skel = (function() { "use strict"; var _ = {
 									return true;
 
 							// Parse query.
-								var s, a, b, k, values = { 'min-width': null, 'max-width': null },
+								var s, a, b, values = { 'min-width': null, 'max-width': null },
 									found = false;
 
 								a = query.split(/\s+and\s+/);
 
-								for (k in a) {
+								for (var k = 0; k < a.length; k++) {
 
 									s = a[k];
 


### PR DESCRIPTION
The for ... in loop shouldn't be used for arrays. On IE8 "a[k]" didn't only return strings, which meant trouble when calling ".charAt".